### PR TITLE
fix(license): align pyproject.toml to MIT — remove Elastic-2.0 contra…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@ description = "Policy evaluation and PII redaction service for GovernsAI"
 authors = [{name = "GovernsAI", email = "team@governs.ai"}]
 readme = "README.md"
 requires-python = ">=3.9"
-license = "Elastic-2.0"
+license = "MIT"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: Other/Proprietary License",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
README.md and LICENSE both declare MIT.
pyproject.toml incorrectly declared 'Elastic-2.0' and 'Other/Proprietary License'. Fixed: license = 'MIT', classifier = 'License :: OSI Approved :: MIT License'.