### PR TITLE
security: hash API keys with HMAC-SHA256, never store plaintext

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -4,18 +4,20 @@ from datetime import datetime
 from typing import Optional
 from .storage import get_db, APIKey
 from .metrics import record_auth_failure
+from .key_utils import hash_api_key
 
 
 async def require_api_key(
     x_governs_key: Optional[str] = Header(None, alias="X-Governs-Key"),
     db: Session = Depends(get_db),
 ) -> str:
-    """Require and validate API key from header against the database."""
+    """Validate API key by comparing HMAC hash — never stores or compares plaintext."""
     if not x_governs_key:
         record_auth_failure("missing_api_key")
         raise HTTPException(status_code=401, detail="missing api key")
 
-    record = db.query(APIKey).filter(APIKey.key == x_governs_key).first()
+    key_hash = hash_api_key(x_governs_key)
+    record = db.query(APIKey).filter(APIKey.key_hash == key_hash).first()
 
     if record is None or not record.is_active:
         record_auth_failure("invalid_api_key")

--- a/app/key_utils.py
+++ b/app/key_utils.py
@@ -1,0 +1,29 @@
+import hashlib
+import hmac
+import os
+import secrets
+
+_KEY_HMAC_SECRET = os.environ.get("KEY_HMAC_SECRET", "").encode()
+
+
+def _hmac_secret() -> bytes:
+    if not _KEY_HMAC_SECRET:
+        raise RuntimeError("KEY_HMAC_SECRET environment variable is required")
+    return _KEY_HMAC_SECRET
+
+
+def hash_api_key(raw_key: str) -> str:
+    """Return HMAC-SHA256 hex digest of raw_key. Store this — never the raw key."""
+    return hmac.new(_hmac_secret(), raw_key.encode(), hashlib.sha256).hexdigest()
+
+
+def generate_api_key() -> tuple[str, str, str]:
+    """Return (raw_key, key_hash, key_prefix). Return raw_key to user once; store hash."""
+    raw_key = "GAI_" + secrets.token_urlsafe(32)
+    key_hash = hash_api_key(raw_key)
+    key_prefix = raw_key[:8]
+    return raw_key, key_hash, key_prefix
+
+
+def constant_time_compare(a: str, b: str) -> bool:
+    return hmac.compare_digest(a.encode(), b.encode())

--- a/app/storage.py
+++ b/app/storage.py
@@ -17,11 +17,14 @@ class User(Base):
 class APIKey(Base):
     __tablename__ = "api_keys"
 
-    key = Column(String, primary_key=True)
+    # key_hash is the HMAC-SHA256 of the raw key — the plaintext key is never
+    # stored after creation. key_prefix stores first 8 chars for display only.
+    key_hash = Column(String, primary_key=True)
+    key_prefix = Column(String, nullable=False)  # e.g. "GAI_ab12" — safe to display
     user_id = Column(String, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
     is_active = Column(Boolean, default=True)
-    expires_at = Column(DateTime, nullable=True)  # None means the key never expires
+    expires_at = Column(DateTime, nullable=True)
 
 class Policy(Base):
     __tablename__ = "policies"


### PR DESCRIPTION
## Summary
API keys were stored in plaintext in the database and compared directly. A DB breach would expose all active keys.

**Changes:**
- `APIKey` model: `key` column replaced with `key_hash` (HMAC-SHA256) + `key_prefix` (first 8 chars for display)
- `auth.py`: incoming key is hashed before lookup — no plaintext ever touches the DB
- `key_utils.py`: `generate_api_key()`, `hash_api_key()`, `constant_time_compare()` helpers

## Required new env var
```
KEY_HMAC_SECRET=<random 32+ char secret>
```

## Migration note
Existing keys in local SQLite will stop working (schema change). Re-create any test API keys after applying. For staging/production, a migration script is needed to hash existing plaintext keys — coordinate with Lambda before deploying.

## Test plan
- [ ] New API key returned on creation (plaintext, one-time only)
- [ ] Same key accepted on subsequent requests
- [ ] Wrong key returns 401
- [ ] DB row contains only hash + prefix, never plaintext

🤖 Generated with [Claude Code](https://claude.com/claude-code)