### PR TITLE
fix: include policy.tool_access.yaml in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,9 @@ RUN python -c "from presidio_analyzer import AnalyzerEngine; \
     anonymizer = AnonymizerEngine(); \
     print('✅ Presidio Anonymizer initialized')"
 
-# Copy application code
+# Copy application code and policy file
 COPY app ./app
+COPY policy.tool_access.yaml ./
 
 # Create non-root user
 RUN useradd --create-home --shell /bin/bash app && \


### PR DESCRIPTION
Dockerfile only copied app/ but not the policy file, causing 500 on all precheck requests.