### PR TITLE
feat(middleware): add X-Response-Time-Ms header

### DIFF
--- a/PROJECT_SPECS.md
+++ b/PROJECT_SPECS.md
@@ -191,6 +191,10 @@ GET /api/metrics
 
 **Response**: Prometheus text format with counters, histograms, and gauges
 
+### Standard Response Headers
+- **`X-Request-ID`**: Unique UUID generated for each request for trace correlation
+- **`X-Response-Time-Ms`**: Integer request duration in milliseconds added to every response
+
 ### Precheck Endpoint
 ```
 POST /api/v1/precheck

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import time
 import uuid
 from contextlib import asynccontextmanager
 
@@ -54,6 +55,14 @@ def create_app() -> FastAPI:
         request_id = str(uuid.uuid4())
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
+        return response
+
+    @app.middleware("http")
+    async def response_time_middleware(request: Request, call_next):
+        start = time.monotonic()
+        response = await call_next(request)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        response.headers["X-Response-Time-Ms"] = str(elapsed_ms)
         return response
 
     app.include_router(router, prefix="/api")

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -8,6 +8,7 @@ client = TestClient(app)
 UUID4_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 )
+INTEGER_RE = re.compile(r"^\d+$")
 
 
 def test_health_has_request_id():
@@ -22,3 +23,11 @@ def test_request_id_is_unique_per_request():
     r2 = client.get("/api/v1/health")
 
     assert r1.headers["x-request-id"] != r2.headers["x-request-id"]
+
+
+def test_response_time_header_is_present_on_success_and_error():
+    success_response = client.get("/api/v1/health")
+    error_response = client.get("/api/v1/does-not-exist")
+
+    assert INTEGER_RE.match(success_response.headers["x-response-time-ms"])
+    assert INTEGER_RE.match(error_response.headers["x-response-time-ms"])


### PR DESCRIPTION
## Summary
- add response-time middleware after request ID middleware in `create_app()`
- return `X-Response-Time-Ms` on success and error responses
- document the standard response header in `PROJECT_SPECS.md`

## GovernsAI Tracker issue
951bc1ca-3416-476e-b0e9-dffedaffa65a

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [x] `source .venv/bin/activate && python -m pytest tests/ -v`