### PR TITLE
fix(auth): load KEY_HMAC_SECRET via pydantic settings

### DIFF
--- a/app/key_utils.py
+++ b/app/key_utils.py
@@ -5,6 +5,7 @@ import secrets
 
 def _hmac_secret() -> bytes:
     from .settings import settings
+
     if not settings.key_hmac_secret:
         raise RuntimeError("KEY_HMAC_SECRET environment variable is required")
     return settings.key_hmac_secret.encode()

--- a/app/key_utils.py
+++ b/app/key_utils.py
@@ -1,15 +1,13 @@
 import hashlib
 import hmac
-import os
 import secrets
-
-_KEY_HMAC_SECRET = os.environ.get("KEY_HMAC_SECRET", "").encode()
 
 
 def _hmac_secret() -> bytes:
-    if not _KEY_HMAC_SECRET:
+    from .settings import settings
+    if not settings.key_hmac_secret:
         raise RuntimeError("KEY_HMAC_SECRET environment variable is required")
-    return _KEY_HMAC_SECRET
+    return settings.key_hmac_secret.encode()
 
 
 def hash_api_key(raw_key: str) -> str:

--- a/app/settings.py
+++ b/app/settings.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
 
     # API configuration — demo_api_key intentionally removed; all keys must live in DB
     api_key_header: str = "X-Governs-Key"
+    key_hmac_secret: str = ""  # REQUIRED in production; loaded from KEY_HMAC_SECRET env var
 
     # Webhook configuration
     # Base URL of the dashboard websocket gateway (e.g. wss://host/ws/gateway).

--- a/app/settings.py
+++ b/app/settings.py
@@ -29,7 +29,9 @@ class Settings(BaseSettings):
 
     # API configuration — demo_api_key intentionally removed; all keys must live in DB
     api_key_header: str = "X-Governs-Key"
-    key_hmac_secret: str = ""  # REQUIRED in production; loaded from KEY_HMAC_SECRET env var
+    key_hmac_secret: str = (
+        ""  # REQUIRED in production; loaded from KEY_HMAC_SECRET env var
+    )
 
     # Webhook configuration
     # Base URL of the dashboard websocket gateway (e.g. wss://host/ws/gateway).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ os.environ.setdefault("WEBHOOK_SECRET", "test-webhook-secret-ci")
 os.environ.setdefault("REDIS_URL", "")  # disable Redis in rate-limiter
 os.environ.setdefault("WEBHOOK_BASE_URL", "")
 os.environ.setdefault("WEBHOOK_CONN_KEY", "")
-# KEY_HMAC_SECRET must be set before key_utils is imported
+# Keep a test-safe default for API key hashing.
 os.environ.setdefault("KEY_HMAC_SECRET", "test-hmac-secret-for-ci-only")
 
 from dataclasses import dataclass

--- a/tests/test_key_utils.py
+++ b/tests/test_key_utils.py
@@ -1,0 +1,23 @@
+import hashlib
+import hmac
+
+import pytest
+
+from app.key_utils import hash_api_key
+from app.settings import settings
+
+
+def test_hash_api_key_reads_secret_from_settings_at_call_time(monkeypatch):
+    raw_key = "GAI_test_key_for_lazy_secret_lookup"
+
+    monkeypatch.setattr(settings, "key_hmac_secret", "")
+    with pytest.raises(RuntimeError, match="KEY_HMAC_SECRET"):
+        hash_api_key(raw_key)
+
+    monkeypatch.setattr(settings, "key_hmac_secret", "late-loaded-secret")
+
+    expected = hmac.new(
+        b"late-loaded-secret", raw_key.encode(), hashlib.sha256
+    ).hexdigest()
+
+    assert hash_api_key(raw_key) == expected


### PR DESCRIPTION
## Summary
- `KEY_HMAC_SECRET` was read from `os.environ` at module import time in `key_utils.py`, before pydantic-settings had a chance to load `.env`
- This caused a `RuntimeError` on any authenticated endpoint when running locally
- Fix: move `key_hmac_secret` into the `Settings` model (pydantic-settings loads it correctly from `.env` or env vars), read it lazily per-call in `_hmac_secret()`

## Test
- Health: `x-request-id` and `x-response-time-ms` headers present ✅  
- Precheck: authenticates correctly, returns 422 on bad payload (not 500) ✅