### PR TITLE
test(T-3): HTTP-level 429 rate limit integration tests + Retry-After header

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -285,7 +285,11 @@ async def precheck(
     else:
         rate_limit_key = f"precheck:key:{api_key}"
     if not rate_limiter.is_allowed(rate_limit_key, limit=100, window=60):
-        raise HTTPException(status_code=429, detail="rate limit exceeded")
+        raise HTTPException(
+            status_code=429,
+            detail="rate limit exceeded",
+            headers={"Retry-After": "60"},
+        )
 
     # Metrics: Track active requests
     set_active_requests("precheck", 1)
@@ -440,7 +444,11 @@ async def postcheck(
     else:
         rate_limit_key = f"postcheck:key:{api_key}"
     if not rate_limiter.is_allowed(rate_limit_key, limit=100, window=60):
-        raise HTTPException(status_code=429, detail="rate limit exceeded")
+        raise HTTPException(
+            status_code=429,
+            detail="rate limit exceeded",
+            headers={"Retry-After": "60"},
+        )
 
     # Metrics: Track active requests
     set_active_requests("postcheck", 1)

--- a/tests/test_rate_limit_http.py
+++ b/tests/test_rate_limit_http.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 GovernsAI. All rights reserved.
+"""
+T-3 — HTTP-level 429 integration test for rate limiting.
+
+Verifies that the /api/v1/precheck endpoint enforces the 100 req/60 s
+sliding-window rate limit at the HTTP layer:
+  - Requests 1-100   → 200
+  - Request 101      → 429 with Retry-After header
+"""
+
+import pytest
+
+from app.rate_limit import rate_limiter
+
+PRECHECK_URL = "/api/v1/precheck"
+
+VALID_PAYLOAD = {
+    "tool": "model.chat",
+    "scope": "net.external",
+    "raw_text": "Rate limit integration test message.",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Clear the in-memory rate limiter state before each test.
+
+    The rate limiter is a module-level singleton.  Without this, request
+    counts from other tests in the same process accumulate and trip the
+    limit before the 100-request mark.
+    """
+    with rate_limiter._local_lock:
+        rate_limiter._local_windows.clear()
+        rate_limiter._local_last_seen.clear()
+    yield
+
+
+def test_precheck_rate_limit_returns_429_after_100_requests(
+    test_client, active_api_key
+):
+    """First 100 requests must succeed; the 101st must return 429."""
+    headers = {"X-Governs-Key": active_api_key.key}
+
+    for i in range(1, 101):
+        resp = test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+        assert (
+            resp.status_code == 200
+        ), f"Expected 200 on request {i}, got {resp.status_code}: {resp.text}"
+
+    # 101st request must be rate-limited
+    resp = test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+    assert (
+        resp.status_code == 429
+    ), f"Expected 429 on request 101, got {resp.status_code}: {resp.text}"
+
+
+def test_precheck_rate_limit_response_has_retry_after_header(
+    test_client, active_api_key
+):
+    """The 429 response must include a Retry-After header set to the window (60 s)."""
+    headers = {"X-Governs-Key": active_api_key.key}
+
+    for _ in range(100):
+        test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+
+    resp = test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+    assert resp.status_code == 429
+    assert "retry-after" in {
+        k.lower() for k in resp.headers
+    }, f"Retry-After header missing from 429 response. Headers: {dict(resp.headers)}"
+    assert (
+        resp.headers["retry-after"] == "60"
+    ), f"Expected Retry-After: 60, got: {resp.headers.get('retry-after')}"


### PR DESCRIPTION
## Summary
- Added `Retry-After: 60` header to both 429 responses in `app/api.py` (precheck + postcheck routes) — was completely absent
- Added `tests/test_rate_limit_http.py` with two integration tests:
  - Sends 101 requests with a valid key — asserts first 100 return 200, 101st returns 429
  - Asserts the 429 carries a `Retry-After: 60` header
- Added `_reset_rate_limiter` autouse fixture to clear in-memory singleton between tests

## What this verifies
Rate limiting is wired correctly end-to-end at the HTTP layer (not just the RateLimiter class). Previously only the class internals were tested.

## Test results
167 tests pass, 65% coverage (threshold: 60%)

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)