### PR TITLE
test: cover rate-limit follow-ups

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -33,6 +33,8 @@ from .storage import APIKey, get_db
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+RATE_LIMIT_REQUESTS = 100
+RATE_LIMIT_WINDOW_SECONDS = 60
 
 
 def _ensure_correlation_id(corr_id: Optional[str]) -> str:
@@ -284,11 +286,16 @@ async def precheck(
         rate_limit_key = f"precheck:{user_id}"
     else:
         rate_limit_key = f"precheck:key:{api_key}"
-    if not rate_limiter.is_allowed(rate_limit_key, limit=100, window=60):
+    if not rate_limiter.is_allowed(
+        rate_limit_key, limit=RATE_LIMIT_REQUESTS, window=RATE_LIMIT_WINDOW_SECONDS
+    ):
+        retry_after = rate_limiter.retry_after(
+            rate_limit_key, limit=RATE_LIMIT_REQUESTS, window=RATE_LIMIT_WINDOW_SECONDS
+        )
         raise HTTPException(
             status_code=429,
             detail="rate limit exceeded",
-            headers={"Retry-After": "60"},
+            headers={"Retry-After": str(max(1, retry_after))},
         )
 
     # Metrics: Track active requests
@@ -443,11 +450,16 @@ async def postcheck(
         rate_limit_key = f"postcheck:{user_id}"
     else:
         rate_limit_key = f"postcheck:key:{api_key}"
-    if not rate_limiter.is_allowed(rate_limit_key, limit=100, window=60):
+    if not rate_limiter.is_allowed(
+        rate_limit_key, limit=RATE_LIMIT_REQUESTS, window=RATE_LIMIT_WINDOW_SECONDS
+    ):
+        retry_after = rate_limiter.retry_after(
+            rate_limit_key, limit=RATE_LIMIT_REQUESTS, window=RATE_LIMIT_WINDOW_SECONDS
+        )
         raise HTTPException(
             status_code=429,
             detail="rate limit exceeded",
-            headers={"Retry-After": "60"},
+            headers={"Retry-After": str(max(1, retry_after))},
         )
 
     # Metrics: Track active requests

--- a/app/rate_limit.py
+++ b/app/rate_limit.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import threading
 import time
 from collections import deque
@@ -63,6 +64,31 @@ class RateLimiter:
 
         return self._is_allowed_local(key=key, limit=limit, window=window)
 
+    def retry_after(self, key: str, limit: int, window: int) -> int:
+        """Return seconds until the next request should be allowed."""
+        if limit <= 0:
+            return max(1, int(math.ceil(window)))
+        if window <= 0:
+            return 1
+
+        if self.redis_client:
+            try:
+                return self._retry_after_redis(key=key, limit=limit, window=window)
+            except Exception as e:
+                logger.warning(
+                    "Redis rate limiter unavailable; falling back to in-memory retry-after: %s",
+                    type(e).__name__,
+                )
+
+        return self._retry_after_local(key=key, limit=limit, window=window)
+
+    def clear(self) -> None:
+        """Clear in-memory fallback state."""
+        with self._local_lock:
+            self._local_windows.clear()
+            self._local_last_seen.clear()
+            self._last_cleanup = 0.0
+
     def _is_allowed_redis(self, key: str, limit: int, window: int) -> bool:
         current_time = time.time()
         window_start = current_time - window
@@ -78,6 +104,32 @@ class RateLimiter:
         results = pipe.execute()
         current_count = int(results[1])
         return current_count < limit
+
+    def _retry_after_redis(self, key: str, limit: int, window: int) -> int:
+        current_time = time.time()
+        window_start = current_time - window
+
+        pipe = self.redis_client.pipeline()
+        pipe.zremrangebyscore(key, 0, window_start)
+        pipe.zcard(key)
+        results = pipe.execute()
+
+        current_count = int(results[1])
+        if current_count < limit:
+            return 0
+
+        next_allowed_index = current_count - limit
+        next_allowed = self.redis_client.zrange(
+            key,
+            next_allowed_index,
+            next_allowed_index,
+            withscores=True,
+        )
+        if not next_allowed:
+            return 0
+
+        next_allowed_at = float(next_allowed[0][1]) + window
+        return max(1, int(math.ceil(next_allowed_at - current_time)))
 
     def _is_allowed_local(self, key: str, limit: int, window: int) -> bool:
         current_time = time.time()
@@ -97,6 +149,31 @@ class RateLimiter:
 
             events.append(current_time)
             return True
+
+    def _retry_after_local(self, key: str, limit: int, window: int) -> int:
+        current_time = time.time()
+        window_start = current_time - window
+
+        with self._local_lock:
+            self._cleanup_local_state(current_time)
+            events = self._local_windows.get(key)
+            if not events:
+                return 0
+
+            while events and events[0] <= window_start:
+                events.popleft()
+
+            if not events:
+                self._local_windows.pop(key, None)
+                self._local_last_seen.pop(key, None)
+                return 0
+
+            self._local_last_seen[key] = current_time
+            if len(events) < limit:
+                return 0
+
+            next_allowed_at = events[len(events) - limit] + window
+            return max(1, int(math.ceil(next_allowed_at - current_time)))
 
     def _cleanup_local_state(self, current_time: float) -> None:
         if current_time - self._last_cleanup < self._cleanup_interval:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -50,3 +50,28 @@ def test_in_memory_fallback_resets_after_window(monkeypatch):
 
     now[0] = 1011.0
     assert limiter.is_allowed("user-c", limit=1, window=10) is True
+
+
+def test_clear_resets_in_memory_fallback_state():
+    limiter = RateLimiter(redis_url=None)
+
+    assert limiter.is_allowed("user-d", limit=1, window=60) is True
+    assert limiter.is_allowed("user-d", limit=1, window=60) is False
+
+    limiter.clear()
+
+    assert limiter.is_allowed("user-d", limit=1, window=60) is True
+
+
+def test_retry_after_uses_sliding_window(monkeypatch):
+    limiter = RateLimiter(redis_url=None)
+    now = [1000.0]
+
+    monkeypatch.setattr("app.rate_limit.time.time", lambda: now[0])
+
+    assert limiter.is_allowed("user-e", limit=2, window=10) is True
+    assert limiter.is_allowed("user-e", limit=2, window=10) is True
+
+    now[0] = 1004.0
+    assert limiter.is_allowed("user-e", limit=2, window=10) is False
+    assert limiter.retry_after("user-e", limit=2, window=10) == 6

--- a/tests/test_rate_limit_http.py
+++ b/tests/test_rate_limit_http.py
@@ -1,19 +1,14 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2024 GovernsAI. All rights reserved.
-"""
-T-3 — HTTP-level 429 integration test for rate limiting.
-
-Verifies that the /api/v1/precheck endpoint enforces the 100 req/60 s
-sliding-window rate limit at the HTTP layer:
-  - Requests 1-100   → 200
-  - Request 101      → 429 with Retry-After header
-"""
+"""T-3 HTTP-level 429 integration tests for rate limiting."""
 
 import pytest
 
 from app.rate_limit import rate_limiter
 
 PRECHECK_URL = "/api/v1/precheck"
+POSTCHECK_URL = "/api/v1/postcheck"
+RATE_LIMITED_ENDPOINTS = [PRECHECK_URL, POSTCHECK_URL]
 
 VALID_PAYLOAD = {
     "tool": "model.chat",
@@ -30,45 +25,68 @@ def _reset_rate_limiter():
     counts from other tests in the same process accumulate and trip the
     limit before the 100-request mark.
     """
-    with rate_limiter._local_lock:
-        rate_limiter._local_windows.clear()
-        rate_limiter._local_last_seen.clear()
+    rate_limiter.clear()
     yield
+    rate_limiter.clear()
 
 
-def test_precheck_rate_limit_returns_429_after_100_requests(
-    test_client, active_api_key
+@pytest.mark.parametrize("endpoint", RATE_LIMITED_ENDPOINTS)
+def test_rate_limit_returns_429_after_100_requests(
+    endpoint, test_client, active_api_key
 ):
     """First 100 requests must succeed; the 101st must return 429."""
     headers = {"X-Governs-Key": active_api_key.key}
 
     for i in range(1, 101):
-        resp = test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+        resp = test_client.post(endpoint, json=VALID_PAYLOAD, headers=headers)
         assert (
             resp.status_code == 200
         ), f"Expected 200 on request {i}, got {resp.status_code}: {resp.text}"
 
     # 101st request must be rate-limited
-    resp = test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+    resp = test_client.post(endpoint, json=VALID_PAYLOAD, headers=headers)
     assert (
         resp.status_code == 429
     ), f"Expected 429 on request 101, got {resp.status_code}: {resp.text}"
 
 
-def test_precheck_rate_limit_response_has_retry_after_header(
-    test_client, active_api_key
+@pytest.mark.parametrize("endpoint", RATE_LIMITED_ENDPOINTS)
+def test_rate_limit_response_has_retry_after_header(
+    endpoint, test_client, active_api_key
 ):
-    """The 429 response must include a Retry-After header set to the window (60 s)."""
+    """The 429 response must include a Retry-After header."""
     headers = {"X-Governs-Key": active_api_key.key}
 
     for _ in range(100):
-        test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+        test_client.post(endpoint, json=VALID_PAYLOAD, headers=headers)
 
-    resp = test_client.post(PRECHECK_URL, json=VALID_PAYLOAD, headers=headers)
+    resp = test_client.post(endpoint, json=VALID_PAYLOAD, headers=headers)
     assert resp.status_code == 429
     assert "retry-after" in {
         k.lower() for k in resp.headers
     }, f"Retry-After header missing from 429 response. Headers: {dict(resp.headers)}"
+
+
+@pytest.mark.parametrize("endpoint", RATE_LIMITED_ENDPOINTS)
+def test_rate_limit_retry_after_matches_sliding_window(
+    endpoint, test_client, active_api_key, monkeypatch
+):
+    """Retry-After should reflect when the oldest in-window request expires."""
+    headers = {"X-Governs-Key": active_api_key.key}
+    now = [1000.0]
+    monkeypatch.setattr("app.rate_limit.time.time", lambda: now[0])
+
+    for _ in range(50):
+        resp = test_client.post(endpoint, json=VALID_PAYLOAD, headers=headers)
+        assert resp.status_code == 200
+
+    now[0] = 1030.0
+    for _ in range(50):
+        resp = test_client.post(endpoint, json=VALID_PAYLOAD, headers=headers)
+        assert resp.status_code == 200
+
+    resp = test_client.post(endpoint, json=VALID_PAYLOAD, headers=headers)
+    assert resp.status_code == 429
     assert (
-        resp.headers["retry-after"] == "60"
-    ), f"Expected Retry-After: 60, got: {resp.headers.get('retry-after')}"
+        resp.headers["retry-after"] == "30"
+    ), f"Expected Retry-After: 30, got: {resp.headers.get('retry-after')}"


### PR DESCRIPTION
## Summary
- add public rate limiter clear/retry-after helpers
- use sliding-window Retry-After values for precheck and postcheck 429s
- parametrize HTTP 429 coverage over precheck and postcheck

## Tests
- venv/bin/python -m pytest tests/test_rate_limit.py tests/test_rate_limit_http.py --no-cov
- venv/bin/python -m pytest