### PR TITLE
feat(policy): canonical YAML policy schema + examples (2.3a)

### DIFF
--- a/PROJECT_SPECS.md
+++ b/PROJECT_SPECS.md
@@ -466,6 +466,74 @@ ws://172.16.10.59:3002/api/ws/gateway?key=gai_827eode3nxa&org=dfy&channels=org:c
 
 ## Policy Configuration
 
+### Canonical Policy-As-Code Schema
+
+Policy-as-code files are validated against the canonical JSON Schema at
+`schemas/policy.schema.json`. The existing `policy.tool_access.yaml` fallback
+file remains supported, and the canonical contract extends that legacy shape
+with explicit sections for PII, budgets, and rate limits so YAML round-trip
+import/export can converge on a single format.
+
+Reference files:
+- `schemas/policy.schema.json`
+- `examples/policies/minimal.yaml`
+- `examples/policies/standard.yaml`
+- `examples/policies/enterprise.yaml`
+
+```yaml
+version: v1
+defaults:
+  ingress:
+    action: redact
+  egress:
+    action: redact
+
+pii:
+  detection: auto
+  default_action: redact
+  entity_rules:
+    "PII:api_key":
+      action: deny
+    "PII:us_ssn":
+      action: tokenize
+
+tool_access:
+  verify_identity:
+    direction: ingress
+    action: confirm
+    allow_pii:
+      "PII:email_address": pass_through
+      "PII:us_ssn": tokenize
+
+budget:
+  scope: user
+  monthly_limit_usd: 500
+  warning_threshold_percent: 90
+  block_on_exceeded: true
+  require_context: true
+
+rate_limits:
+  default:
+    requests: 100
+    window_seconds: 60
+    key: user
+
+deny_tools:
+  - python.exec
+  - bash.exec
+  - code.exec
+  - shell.exec
+network_scopes:
+  - net.
+network_tools:
+  - web.
+  - http.
+  - fetch.
+  - request.
+on_error: block
+model: gpt-4
+```
+
 ### Tool Access Policy (`policy.tool_access.yaml`)
 
 ```yaml
@@ -505,6 +573,7 @@ tool_access:
 - **`tokenize`**: Replace PII with stable token (e.g., `pii_8797942a`)
 - **`redact`**: Apply standard redaction (e.g., `<USER_EMAIL>`, `<USER_SSN>`)
 - **`deny`**: Block the request entirely
+- **`confirm`**: Require an approval/confirmation step before tool execution
 
 ### Global Defaults
 

--- a/examples/policies/enterprise.yaml
+++ b/examples/policies/enterprise.yaml
@@ -1,0 +1,86 @@
+version: v1
+description: Organization-wide policy with dual-direction tool controls, org budgets, and stricter outbound rate limits.
+defaults:
+  ingress:
+    action: redact
+  egress:
+    action: tokenize
+pii:
+  detection: presidio
+  default_action: redact
+  entity_rules:
+    "PII:email_address":
+      action: pass_through
+      description: Customer success workflows may route on raw email addresses.
+    "PII:phone_number":
+      action: tokenize
+      description: Tokenize phone numbers before external transmission.
+    "PII:us_ssn":
+      action: tokenize
+      description: SSNs are always tokenized in enterprise exports.
+    "PII:api_key":
+      action: deny
+      description: Secrets are blocked across all tools.
+tool_access:
+  verify_identity:
+    direction: both
+    action: confirm
+    allow_pii:
+      "PII:email_address": pass_through
+      "PII:phone_number": tokenize
+      "PII:us_ssn": tokenize
+  payment_processor:
+    direction: ingress
+    action: confirm
+    allow_pii:
+      "PII:email_address": pass_through
+      "PII:credit_card": tokenize
+  audit_log:
+    direction: egress
+    allow_pii:
+      "PII:email_address": pass_through
+      "PII:us_ssn": tokenize
+  security_incident_export:
+    direction: egress
+    action: confirm
+    allow_pii:
+      "PII:api_key": deny
+      "PII:jwt": deny
+budget:
+  scope: organization
+  monthly_limit_usd: 10000
+  warning_threshold_percent: 85
+  block_on_exceeded: true
+  require_context: true
+rate_limits:
+  default:
+    requests: 250
+    window_seconds: 60
+    key: organization
+  overrides:
+    payment_processor:
+      requests: 60
+      window_seconds: 60
+      key: organization
+      burst: 10
+    security_incident_export:
+      requests: 10
+      window_seconds: 300
+      key: organization
+deny_tools:
+  - python.exec
+  - bash.exec
+  - code.exec
+  - shell.exec
+  - terraform.apply
+network_scopes:
+  - net.
+  - partner.
+network_tools:
+  - web.
+  - http.
+  - fetch.
+  - request.
+  - webhook.
+on_error: best_effort
+model: gpt-4.1

--- a/examples/policies/minimal.yaml
+++ b/examples/policies/minimal.yaml
@@ -1,0 +1,24 @@
+version: v1
+description: Minimal baseline policy with safe defaults and network redaction.
+defaults:
+  ingress:
+    action: redact
+  egress:
+    action: redact
+pii:
+  detection: auto
+  default_action: redact
+deny_tools:
+  - python.exec
+  - bash.exec
+  - code.exec
+  - shell.exec
+network_scopes:
+  - net.
+network_tools:
+  - web.
+  - http.
+  - fetch.
+  - request.
+on_error: block
+model: gpt-4o-mini

--- a/examples/policies/standard.yaml
+++ b/examples/policies/standard.yaml
@@ -1,0 +1,66 @@
+version: v1
+description: Team-level policy with reusable PII rules, per-tool overrides, budget caps, and user rate limits.
+defaults:
+  ingress:
+    action: redact
+  egress:
+    action: redact
+pii:
+  detection: auto
+  default_action: redact
+  entity_rules:
+    "PII:email_address":
+      action: pass_through
+      description: Allow verified communication tools to receive raw email addresses.
+    "PII:us_ssn":
+      action: tokenize
+      description: Tokenize SSNs before they leave the service boundary.
+    "PII:api_key":
+      action: deny
+      description: Never expose secrets to downstream tools.
+tool_access:
+  verify_identity:
+    direction: ingress
+    action: confirm
+    allow_pii:
+      "PII:email_address": pass_through
+      "PII:us_ssn": tokenize
+  send_marketing_email:
+    direction: ingress
+    allow_pii:
+      "PII:email_address": pass_through
+  data_export:
+    direction: egress
+    allow_pii:
+      "PII:email_address": pass_through
+      "PII:us_ssn": tokenize
+budget:
+  scope: user
+  monthly_limit_usd: 500
+  warning_threshold_percent: 90
+  block_on_exceeded: true
+  require_context: true
+rate_limits:
+  default:
+    requests: 100
+    window_seconds: 60
+    key: user
+  overrides:
+    send_marketing_email:
+      requests: 20
+      window_seconds: 60
+      key: user
+deny_tools:
+  - python.exec
+  - bash.exec
+  - code.exec
+  - shell.exec
+network_scopes:
+  - net.
+network_tools:
+  - web.
+  - http.
+  - fetch.
+  - request.
+on_error: block
+model: gpt-4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
+    "jsonschema>=4.23.0",
     "presidio-analyzer>=2.2.0",
     "presidio-anonymizer>=2.2.0",
     "spacy>=3.7.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ websockets>=12.0
 # Configuration and Utilities
 python-multipart>=0.0.6
 pyyaml>=6.0.0
+jsonschema>=4.23.0
 
 # Monitoring and Metrics
 prometheus-client>=0.19.0

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.governs.ai/precheck/policy.schema.json",
+  "title": "GovernsAI Precheck Policy",
+  "description": "Canonical policy-as-code schema for GovernsAI Precheck YAML policies.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "defaults"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "version": {
+      "const": "v1"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "defaults": {
+      "$ref": "#/$defs/directionDefaults"
+    },
+    "pii": {
+      "$ref": "#/$defs/piiPolicy"
+    },
+    "tool_access": {
+      "$ref": "#/$defs/toolAccess"
+    },
+    "budget": {
+      "$ref": "#/$defs/budgetPolicy"
+    },
+    "rate_limits": {
+      "$ref": "#/$defs/rateLimitsPolicy"
+    },
+    "deny_tools": {
+      "$ref": "#/$defs/nonEmptyStringArray"
+    },
+    "network_scopes": {
+      "$ref": "#/$defs/nonEmptyStringArray"
+    },
+    "network_tools": {
+      "$ref": "#/$defs/nonEmptyStringArray"
+    },
+    "on_error": {
+      "type": "string",
+      "enum": [
+        "block",
+        "pass",
+        "best_effort"
+      ],
+      "default": "block"
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1,
+      "default": "gpt-4"
+    }
+  },
+  "$defs": {
+    "nonEmptyStringArray": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "directionDefaultAction": {
+      "type": "string",
+      "enum": [
+        "redact",
+        "deny",
+        "pass_through",
+        "tokenize"
+      ]
+    },
+    "piiAction": {
+      "type": "string",
+      "enum": [
+        "redact",
+        "deny",
+        "block",
+        "pass_through",
+        "tokenize"
+      ]
+    },
+    "toolAction": {
+      "type": "string",
+      "enum": [
+        "redact",
+        "deny",
+        "block",
+        "pass_through",
+        "tokenize",
+        "confirm"
+      ]
+    },
+    "directionDefault": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/directionDefaultAction"
+        }
+      }
+    },
+    "directionDefaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ingress",
+        "egress"
+      ],
+      "properties": {
+        "ingress": {
+          "$ref": "#/$defs/directionDefault"
+        },
+        "egress": {
+          "$ref": "#/$defs/directionDefault"
+        }
+      }
+    },
+    "piiEntityRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/piiAction"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "piiEntityRules": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^PII:[A-Za-z0-9_:-]+$"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/piiEntityRule"
+      }
+    },
+    "piiPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "detection": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "presidio",
+            "regex"
+          ],
+          "default": "auto"
+        },
+        "default_action": {
+          "$ref": "#/$defs/piiAction"
+        },
+        "entity_rules": {
+          "$ref": "#/$defs/piiEntityRules"
+        }
+      }
+    },
+    "allowPiiMap": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^PII:[A-Za-z0-9_:-]+$"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/piiAction"
+      }
+    },
+    "toolPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "direction"
+      ],
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": [
+            "ingress",
+            "egress",
+            "both"
+          ]
+        },
+        "action": {
+          "$ref": "#/$defs/toolAction"
+        },
+        "allow_pii": {
+          "$ref": "#/$defs/allowPiiMap"
+        }
+      }
+    },
+    "toolAccess": {
+      "type": "object",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/toolPolicy"
+      }
+    },
+    "budgetPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "monthly_limit_usd"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": [
+            "user",
+            "organization"
+          ],
+          "default": "user"
+        },
+        "monthly_limit_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "warning_threshold_percent": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 100,
+          "default": 90
+        },
+        "block_on_exceeded": {
+          "type": "boolean",
+          "default": true
+        },
+        "require_context": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "rateLimitRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requests",
+        "window_seconds"
+      ],
+      "properties": {
+        "requests": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "window_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string",
+          "enum": [
+            "user",
+            "organization",
+            "api_key"
+          ],
+          "default": "user"
+        },
+        "burst": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "rateLimitsPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/rateLimitRule"
+        },
+        "overrides": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/rateLimitRule"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_policy_schema_examples.py
+++ b/tests/test_policy_schema_examples.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "policy.schema.json"
+EXAMPLES_DIR = ROOT / "examples" / "policies"
+EXPECTED_EXAMPLES = ["enterprise.yaml", "minimal.yaml", "standard.yaml"]
+
+
+def _load_schema():
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _load_policy(path: Path):
+    return yaml.safe_load(path.read_text())
+
+
+def _policy_examples():
+    return sorted(EXAMPLES_DIR.glob("*.yaml"))
+
+
+def test_expected_example_policies_exist():
+    assert [path.name for path in _policy_examples()] == EXPECTED_EXAMPLES
+
+
+def test_policy_schema_is_valid_json_schema():
+    Draft202012Validator.check_schema(_load_schema())
+
+
+@pytest.mark.parametrize("policy_path", _policy_examples(), ids=lambda path: path.stem)
+def test_example_policy_validates_against_schema(policy_path: Path):
+    validator = Draft202012Validator(_load_schema())
+    policy = _load_policy(policy_path)
+
+    errors = sorted(
+        validator.iter_errors(policy),
+        key=lambda error: list(error.absolute_path),
+    )
+
+    assert not errors, "\n".join(
+        f"{policy_path.name}: {'/'.join(map(str, error.absolute_path))} {error.message}"
+        for error in errors
+    )


### PR DESCRIPTION
## Summary
- add the canonical policy-as-code JSON Schema for precheck YAML policies
- add minimal, standard, and enterprise example policy files
- validate the schema and examples in pytest, and document the canonical contract in PROJECT_SPECS.md

## GovernsAI Tracker issue
GOV-564

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [x] .venv/bin/pytest tests/ -v