### PR TITLE
feat(pii): bundle multilingual spaCy models in precheck image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,26 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Download spaCy models for Presidio
+# English (default, used today by the analyzer)
 RUN python -m spacy download en_core_web_sm && \
     python -m spacy download en_core_web_lg
+
+# Multilingual models (GOV-585 / TASKS.md §3.5a).
+# These are pre-installed so the image is ready to serve non-English PII
+# detection once the NLP engine config is enabled per-org in 3.5b+.
+# Kept as a separate layer so the English-only base is still cache-hot for
+# builds that don't touch multilingual code.
+RUN python -m spacy download es_core_news_sm && \
+    python -m spacy download fr_core_news_sm && \
+    python -m spacy download de_core_news_sm && \
+    python -m spacy download zh_core_web_sm
+
+# Fail the image build if any multilingual model fails to load. This is the
+# acceptance check for TASKS.md §3.5a — each model must load without errors in
+# the precheck container — and it prints the cold-load time per model so the
+# startup cost is visible in CI logs.
+COPY scripts/smoke_multilingual_pii.py /tmp/smoke_multilingual_pii.py
+RUN python /tmp/smoke_multilingual_pii.py && rm /tmp/smoke_multilingual_pii.py
 
 # Verify Presidio installation and download required models
 RUN python -c "from presidio_analyzer import AnalyzerEngine; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=60"
 asyncio_mode = "auto"
+markers = [
+    "multilingual: tests that require non-English spaCy models (run inside the precheck image)",
+]
 
 [tool.coverage.run]
 source = ["app"]

--- a/scripts/smoke_multilingual_pii.py
+++ b/scripts/smoke_multilingual_pii.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 GovernsAI. All rights reserved.
+"""
+Smoke test for multilingual spaCy models baked into the precheck image.
+
+Run inside the built container:
+
+    docker run --rm <image> python scripts/smoke_multilingual_pii.py
+
+Exits non-zero if any configured model fails to load, which is how CI (and the
+Dockerfile RUN layer, if the test is wired there) enforces the acceptance
+criteria for GOV-585 / TASKS.md §3.5a.
+
+The script also prints per-model load times so we can track the startup-cost
+impact of the multilingual models over time.
+"""
+
+import sys
+import time
+from typing import List, Tuple
+
+MODELS: List[str] = [
+    "en_core_web_sm",
+    "es_core_news_sm",
+    "fr_core_news_sm",
+    "de_core_news_sm",
+    "zh_core_web_sm",
+]
+
+
+def _load_all() -> Tuple[List[Tuple[str, float]], List[Tuple[str, str]]]:
+    import spacy
+
+    ok: List[Tuple[str, float]] = []
+    failed: List[Tuple[str, str]] = []
+    for model in MODELS:
+        t0 = time.perf_counter()
+        try:
+            spacy.load(model)
+        except Exception as exc:
+            failed.append((model, f"{type(exc).__name__}: {exc}"))
+            continue
+        ok.append((model, time.perf_counter() - t0))
+    return ok, failed
+
+
+def main() -> int:
+    ok, failed = _load_all()
+
+    for model, elapsed in ok:
+        print(f"loaded  {model:<22} {elapsed*1000:7.1f} ms")
+    for model, err in failed:
+        print(f"FAILED  {model:<22} {err}")
+
+    total = sum(elapsed for _, elapsed in ok)
+    print(f"total cold-load time across {len(ok)} model(s): {total*1000:.1f} ms")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_multilingual_models.py
+++ b/tests/test_multilingual_models.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 GovernsAI. All rights reserved.
+"""
+TEST-3.5a — Multilingual spaCy model smoke tests.
+
+The precheck container ships with spaCy models for English plus Spanish,
+French, German and Mandarin Chinese (TASKS.md §3.5a / GOV-585). These tests
+assert each model can be loaded without error so we catch regressions in the
+Dockerfile (e.g. a typo'd model name, or a spaCy major-version bump that drops
+an old model) before the image reaches prod.
+
+Outside the container the models may not be installed locally; in that case
+the test is skipped rather than failed. CI should run `pytest -m multilingual`
+inside the built precheck image (or invoke scripts/smoke_multilingual_pii.py)
+to enforce the acceptance criteria.
+"""
+
+import importlib.util
+import time
+
+import pytest
+
+MULTILINGUAL_MODELS = [
+    "es_core_news_sm",
+    "fr_core_news_sm",
+    "de_core_news_sm",
+    "zh_core_web_sm",
+]
+
+
+def _spacy_or_skip():
+    if importlib.util.find_spec("spacy") is None:
+        pytest.skip("spaCy not installed in this environment")
+    import spacy
+
+    return spacy
+
+
+def _require_model(spacy_mod, model_name: str):
+    if importlib.util.find_spec(model_name) is None:
+        pytest.skip(f"{model_name} not installed locally; run inside precheck image")
+    return spacy_mod.load(model_name)
+
+
+@pytest.mark.multilingual
+@pytest.mark.parametrize("model_name", MULTILINGUAL_MODELS)
+def test_multilingual_model_loads(model_name):
+    """Each configured multilingual spaCy model loads without raising."""
+    spacy = _spacy_or_skip()
+    nlp = _require_model(spacy, model_name)
+    assert nlp is not None
+    assert nlp.lang == model_name.split("_", 1)[0]
+
+
+@pytest.mark.multilingual
+@pytest.mark.parametrize(
+    "model_name,text",
+    [
+        ("es_core_news_sm", "Juan vive en Madrid."),
+        ("fr_core_news_sm", "Marie habite à Paris."),
+        ("de_core_news_sm", "Hans wohnt in Berlin."),
+        ("zh_core_web_sm", "李雷住在北京。"),
+    ],
+)
+def test_multilingual_model_pipeline_runs(model_name, text):
+    """Each model's pipeline executes on a short language-appropriate sample."""
+    spacy = _spacy_or_skip()
+    nlp = _require_model(spacy, model_name)
+    doc = nlp(text)
+    assert len(list(doc)) > 0
+
+
+@pytest.mark.multilingual
+def test_all_models_cold_load_under_budget():
+    """Combined cold-load for all multilingual models stays under 10s budget.
+
+    The budget is deliberately generous — we only want to catch a future
+    regression where a model balloons in size or spaCy changes its load path.
+    """
+    spacy = _spacy_or_skip()
+
+    total = 0.0
+    for model in MULTILINGUAL_MODELS:
+        _require_model(spacy, model)
+        t0 = time.perf_counter()
+        spacy.load(model)
+        total += time.perf_counter() - t0
+    assert total < 10.0, f"multilingual cold load took {total:.2f}s (budget 10s)"


### PR DESCRIPTION
## Summary
- Adds Spanish (`es_core_news_sm`), French (`fr_core_news_sm`), German (`de_core_news_sm`) and Mandarin (`zh_core_web_sm`) spaCy models to the precheck Docker image.
- Installs them in a separate layer so the English-only base stays cache-hot for unrelated builds.
- Adds `scripts/smoke_multilingual_pii.py` — loads every model and prints per-model cold-load times; the Dockerfile runs it so the image build fails if any model is broken.
- Adds `tests/test_multilingual_models.py` gated by a new `multilingual` pytest marker; runs inside the precheck container (or any env where the models are installed) and skips cleanly otherwise.
- No runtime code is wired to the new models yet — that is 3.5b. Presidio's NLP engine still boots with `supported_languages=["en"]`.

## Load-time impact
Local run (python 3.14, spaCy 3.8.13), per-model cold load:
| model | cold load |
| --- | --- |
| `en_core_web_sm` | 308 ms |
| `es_core_news_sm` | 99 ms |
| `fr_core_news_sm` | 1208 ms |
| `de_core_news_sm` | 252 ms |
| `zh_core_web_sm` | 1022 ms |
| **total** | **~2.9 s** |

These only register when the NLP engine is extended to actually load them (3.5b); today the service startup path is unchanged because `build_presidio()` still requests English only. Image-build time increases by the download + install of the four new small models (~70 MB on disk combined).

## GovernsAI Tracker issue
[GOV-585](mention://issue/9bb91f4c-2f36-4fda-9147-c1566879a33a)

## Reviewers
Tagging Atlas — precheck change, required per SDLC rules.

## Test plan
- [x] `python scripts/smoke_multilingual_pii.py` loads all 5 models locally (see table above).
- [x] `pytest tests/test_multilingual_models.py` — 9 passed.
- [ ] CI image build completes with the new smoke `RUN` step.
- [ ] `docker run --rm <image> python scripts/smoke_multilingual_pii.py` inside the built precheck image (spot check by reviewer).

## Out of scope (follow-up tasks)
- 3.5b: extend Presidio `NlpEngine` config + per-org language selection.
- 3.5c: multilingual recognizers for existing entity types (phone numbers, IDs).