### PR TITLE
test: add precheck k6 load test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,94 @@ jobs:
       - name: pytest with coverage (>=60% required)
         run: pytest tests/ -v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=60
 
+  load-test:
+    name: Load Test
+    runs-on: ubuntu-latest
+    needs: [test]
+    env:
+      APP_BIND: 127.0.0.1:8082
+      DB_URL: sqlite:///./loadtest.db
+      DEBUG: "false"
+      KEY_HMAC_SECRET: ci-load-hmac-secret
+      PII_TOKEN_SALT: ci-load-salt
+      WEBHOOK_SECRET: ci-load-webhook-secret
+      PRECHECK_DLQ: /tmp/precheck-load.dlq.jsonl
+      LOAD_TEST_API_KEY: GAI_ci_load_test_key
+      PRECHECK_BASE_URL: http://127.0.0.1:8082
+      LOAD_USER_POOL_SIZE: "120"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - uses: grafana/setup-k6-action@v1
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Seed load-test API key
+        run: |
+          python scripts/seed_test_api_key.py \
+            --key "${LOAD_TEST_API_KEY}" \
+            --user-id "load-test-user" \
+            --org-id "load-test-org"
+
+      - name: Start precheck service
+        run: |
+          python start.py > /tmp/precheck-load.log 2>&1 &
+          echo $! > /tmp/precheck-load.pid
+
+      - name: Wait for health check
+        run: |
+          python - <<'EOF'
+          import sys
+          import time
+          import httpx
+
+          url = "http://127.0.0.1:8082/api/v1/health"
+          for attempt in range(30):
+              try:
+                  response = httpx.get(url, timeout=5.0)
+                  if response.status_code == 200:
+                      print("precheck load-test service ready")
+                      sys.exit(0)
+              except Exception:
+                  pass
+              time.sleep(1)
+
+          print("precheck service failed to start for load test")
+          sys.exit(1)
+          EOF
+
+      - name: Run k6 load test
+        run: |
+          mkdir -p tests/load/artifacts
+          k6 run \
+            --summary-export tests/load/artifacts/precheck-load-summary.json \
+            --out json=tests/load/artifacts/precheck-load-results.json \
+            tests/load/precheck_load.js
+        env:
+          PRECHECK_API_KEY: ${{ env.LOAD_TEST_API_KEY }}
+
+      - name: Stop precheck service
+        if: always()
+        run: |
+          if [ -f /tmp/precheck-load.pid ]; then
+            kill "$(cat /tmp/precheck-load.pid)" || true
+          fi
+
+      - name: Upload load-test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: precheck-load-test-report
+          path: |
+            tests/load/artifacts
+            /tmp/precheck-load.log
+
   smoke:
     name: Smoke (deployed)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev test format lint type-check clean run docker-build docker-run
+.PHONY: install install-dev test load-test format lint type-check clean run docker-build docker-run
 
 # Install production dependencies
 install:
@@ -13,6 +13,15 @@ install-dev:
 # Run tests
 test:
 	pytest tests/ -v
+
+# Run the k6 load test (requires a running local service and a seeded API key)
+load-test:
+	@test -n "$(PRECHECK_API_KEY)" || (echo "PRECHECK_API_KEY is required"; exit 1)
+	mkdir -p tests/load/artifacts
+	k6 run \
+		--summary-export tests/load/artifacts/precheck-load-summary.json \
+		--out json=tests/load/artifacts/precheck-load-results.json \
+		tests/load/precheck_load.js
 
 # Format code
 format:

--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ python -m spacy download en_core_web_sm
 pytest tests/
 ```
 
+### Running Load Tests
+
+Seed or reactivate a test API key in your local database, then run the k6 script:
+
+```bash
+python scripts/seed_test_api_key.py --key GAI_local_load_test_key --user-id load-test-user --org-id load-test-org
+PRECHECK_API_KEY=GAI_local_load_test_key make load-test
+```
+
+The load test targets `POST /api/v1/precheck` at `100 req/s` for `30s` and spreads
+requests across synthetic `user_id` values so the aggregate traffic does not trip
+the service's per-user rate limiter.
+
 ### Code Formatting
 
 ```bash

--- a/scripts/seed_test_api_key.py
+++ b/scripts/seed_test_api_key.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Seed or reactivate a deterministic API key for local/CI test traffic.
+
+Usage:
+    KEY_HMAC_SECRET=... python scripts/seed_test_api_key.py \
+      --key GAI_ci_load_test_key \
+      --user-id load-test-user \
+      --org-id load-test-org
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+os.chdir(REPO_ROOT)
+sys.path.insert(0, REPO_ROOT)
+
+from sqlalchemy import select
+
+from app.key_utils import hash_api_key
+from app.storage import APIKey, SessionLocal, create_tables
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed or reactivate an API key record for local/CI tests."
+    )
+    parser.add_argument("--key", required=True, help="Raw API key value to seed")
+    parser.add_argument("--user-id", required=True, help="User ID to attach")
+    parser.add_argument("--org-id", default=None, help="Org ID to attach")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    create_tables()
+    session = SessionLocal()
+
+    try:
+        key_hash = hash_api_key(args.key)
+        record = session.scalar(select(APIKey).where(APIKey.key_hash == key_hash))
+
+        if record is None:
+            record = APIKey(
+                key_hash=key_hash,
+                key_prefix=args.key[:8],
+                user_id=args.user_id,
+                org_id=args.org_id,
+                created_at=datetime.utcnow(),
+                is_active=True,
+                expires_at=None,
+            )
+            session.add(record)
+            action = "created"
+        else:
+            record.key_prefix = args.key[:8]
+            record.user_id = args.user_id
+            record.org_id = args.org_id
+            record.is_active = True
+            record.expires_at = None
+            action = "updated"
+
+        session.commit()
+        print(
+            json.dumps(
+                {
+                    "status": action,
+                    "key_prefix": record.key_prefix,
+                    "user_id": record.user_id,
+                    "org_id": record.org_id,
+                    "is_active": bool(record.is_active),
+                }
+            )
+        )
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/load/.gitignore
+++ b/tests/load/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/tests/load/precheck_load.js
+++ b/tests/load/precheck_load.js
@@ -1,0 +1,80 @@
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check } from 'k6';
+
+const baseUrl = (__ENV.PRECHECK_BASE_URL || 'http://127.0.0.1:8082').replace(
+  /\/$/,
+  '',
+);
+const apiKey = __ENV.PRECHECK_API_KEY;
+const userPoolSize = Number(__ENV.LOAD_USER_POOL_SIZE || 120);
+const rate = Number(__ENV.LOAD_RATE || 100);
+const duration = __ENV.LOAD_DURATION || '30s';
+const preAllocatedVUs = Number(__ENV.LOAD_PREALLOCATED_VUS || 50);
+const maxVUs = Number(__ENV.LOAD_MAX_VUS || 200);
+
+if (!apiKey) {
+  throw new Error('PRECHECK_API_KEY is required');
+}
+
+if (!Number.isFinite(userPoolSize) || userPoolSize < 2) {
+  throw new Error('LOAD_USER_POOL_SIZE must be at least 2');
+}
+
+export const options = {
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+  thresholds: {
+    http_req_duration: ['p(95)<200'],
+    http_req_failed: ['rate<0.01'],
+    checks: ['rate>0.99'],
+  },
+  scenarios: {
+    precheck_constant_rate: {
+      executor: 'constant-arrival-rate',
+      rate,
+      timeUnit: '1s',
+      duration,
+      preAllocatedVUs,
+      maxVUs,
+      gracefulStop: '0s',
+    },
+  },
+};
+
+function buildPayload(iteration) {
+  return JSON.stringify({
+    tool: 'model.chat',
+    scope: 'net.internal',
+    raw_text: 'Load-test clean text that should not trigger PII redaction.',
+    user_id: `load-user-${iteration % userPoolSize}`,
+    corr_id: `load-${iteration}`,
+    tags: ['load', 'ci'],
+  });
+}
+
+export default function () {
+  const iteration = exec.scenario.iterationInTest;
+  const response = http.post(`${baseUrl}/api/v1/precheck`, buildPayload(iteration), {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Governs-Key': apiKey,
+    },
+    tags: {
+      endpoint: 'precheck',
+    },
+  });
+
+  let body = null;
+  if (response.status === 200) {
+    try {
+      body = response.json();
+    } catch (_) {
+      body = null;
+    }
+  }
+
+  check(response, {
+    'status is 200': (res) => res.status === 200,
+    'response contains decision': () => Boolean(body && body.decision),
+  });
+}


### PR DESCRIPTION
## Summary
- add a repo-local k6 load test for 
- add a deterministic API key seeding helper for CI/local runs
- extend CI to run the load test and upload summary/raw artifacts

## Verification
- black --check app/ tests/
- isort --check-only app/ tests/
- flake8 app/ tests/ --max-line-length=88 --extend-ignore=E203,W503,E501,F401,F811,F841,E402
- mypy app/ --ignore-missing-imports
- pytest tests/ -v --tb=short --cov=app --cov-report=term-missing --cov-fail-under=60
- dockerized k6 run at 100 req/s for 30s: p95=6.82ms, 0.00% HTTP failures