### PR TITLE
fix(settings): reject KEY_HMAC_SECRET dev default in all environments

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -5,6 +5,11 @@ from pydantic_settings import BaseSettings
 
 _DEFAULT_SALT = "dev-pii-token-salt-change-in-production"
 _DEFAULT_WEBHOOK_SECRET = "dev-webhook-secret-change-in-production"
+# Debug HMAC keys are deterministic and publicly known. Never restore a debug
+# database into a non-debug environment — any API-key HMAC signed with this
+# marker is trivially forgeable. The model validator below rejects this value
+# for KEY_HMAC_SECRET in all environments (including DEBUG=true) because the
+# key identity boundary must never resolve to a shared default.
 _DEFAULT_KEY_HMAC_SECRET = "dev-key-hmac-secret-change-in-production"
 _MIN_SECRET_LENGTH = 32
 
@@ -35,6 +40,9 @@ class Settings(BaseSettings):
 
     # API configuration — demo_api_key intentionally removed; all keys must live in DB
     api_key_header: str = "X-Governs-Key"
+    # HMAC secret used to derive API-key identity hashes. This is the API-key
+    # identity boundary, so the dev default marker is rejected in every
+    # environment (see _reject_default_secrets below) — not only in production.
     key_hmac_secret: str = _DEFAULT_KEY_HMAC_SECRET
 
     # Webhook configuration
@@ -64,6 +72,15 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _reject_default_secrets(self) -> "Settings":
+        # KEY_HMAC_SECRET is the API-key identity boundary: a shared default
+        # here means any caller can forge a valid key hash. Reject the dev
+        # marker even in DEBUG mode — the operator must supply a unique value.
+        if self.key_hmac_secret == _DEFAULT_KEY_HMAC_SECRET:
+            raise ValueError(
+                "KEY_HMAC_SECRET must be replaced with a unique, high-entropy "
+                "value in every environment (including debug); the dev default "
+                "is deterministic and publicly known."
+            )
         if not self.debug:
             self._validate_secret(
                 name="PII_TOKEN_SALT",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -62,3 +62,28 @@ def test_settings_reject_default_non_debug_secret_markers(monkeypatch, env_var, 
 
     with pytest.raises(ValueError, match=env_var):
         Settings(_env_file=None)
+
+
+@pytest.mark.parametrize("debug_flag", ["true", "false"])
+def test_settings_reject_default_key_hmac_secret_in_all_envs(monkeypatch, debug_flag):
+    """KEY_HMAC_SECRET is the API-key identity boundary — the dev default
+    marker must be rejected regardless of DEBUG mode."""
+    _set_non_debug_safe_env(monkeypatch)
+    monkeypatch.setenv("DEBUG", debug_flag)
+    monkeypatch.setenv("KEY_HMAC_SECRET", "dev-key-hmac-secret-change-in-production")
+
+    with pytest.raises(ValueError, match="KEY_HMAC_SECRET"):
+        Settings(_env_file=None)
+
+
+def test_settings_accept_non_default_key_hmac_in_debug(monkeypatch):
+    """DEBUG mode still accepts any non-default KEY_HMAC_SECRET, including
+    short dev-only values — only the public dev marker is rejected."""
+    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./debug.db")
+    monkeypatch.delenv("DB_URL", raising=False)
+    monkeypatch.setenv("KEY_HMAC_SECRET", "local-dev-unique-hmac")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.key_hmac_secret == "local-dev-unique-hmac"


### PR DESCRIPTION
## Summary

Follow-up to Cipher's GOV-573 review of [precheck#31](https://github.com/Governs-AI/precheck/pull/31). The default for `key_hmac_secret` shifted from `\"\"` to `_DEFAULT_KEY_HMAC_SECRET`, which meant the service signed API-key HMACs with a publicly-known marker string under `DEBUG=true`. Because `KEY_HMAC_SECRET` is the API-key identity boundary (not a recoverable webhook signature), the dev marker is now rejected in every environment.

### Changes
- **`app/settings.py`** — Added explanatory comment on `_DEFAULT_KEY_HMAC_SECRET` and a docstring on the `key_hmac_secret` field noting the debug-marker danger.
- **`app/settings.py`** — Promoted the default-marker check for `KEY_HMAC_SECRET` out of the `if not self.debug:` branch so it runs unconditionally.
- **`tests/test_settings.py`** — Added a parametrized test over `DEBUG=true` and `DEBUG=false` confirming the dev marker is rejected in both, plus a positive test that a non-default dev value still starts cleanly.

### Breaking change
Operators running with `DEBUG=true` and the default `KEY_HMAC_SECRET` will now fail fast at startup. The repo's `tests/conftest.py` already sets a unique value (`test-hmac-secret-for-ci-only`), and `env.example` already flags the variable as required — any local dev env that relied on the silent default must now set one.

## GovernsAI Tracker issue
[GOV-1486](https://github.com/Governs-AI/precheck/pull/1486)

## Reviewers
Tagging Nexus (code quality) and Cipher (security/arch) — both approvals required.

## Test plan
- [x] \`python -m black --check app/ tests/\`
- [x] \`python -m isort --check-only app/ tests/\`
- [x] \`python -m pytest tests/ --no-cov\` — 192 passed, 9 skipped
- [x] New parametrized test verifies rejection under both \`DEBUG=true\` and \`DEBUG=false\`
- [x] New positive test verifies non-default dev values still start cleanly